### PR TITLE
fix swiftLint.yml の記述を最新版に変更

### DIFF
--- a/Project-iOS/XLProjectName/.swiftlint.yml
+++ b/Project-iOS/XLProjectName/.swiftlint.yml
@@ -1,50 +1,32 @@
-disabled_rules: # rule identifiers to exclude from running
-  - line_length            # 1 行の長さ
-  - trailing_whitespace    # 行末に余計なスペース
-#  - colon
-#  - comma
-#  - control_statement
-#  - file_length
-#  - force_cast
-  - force_try
-#  - function_body_length
-#  - leading_whitespace
-#  - line_length
-#  - nesting
-#  - operator_whitespace
-#  - opening_brace
-#  - return_arrow_whitespace
-#  - statement_position
-#  - todo
-#  - trailing_newline
-#  - trailing_semicolon
-#  - type_body_length
-#  - type_name
-#  - valid_docs
-#  - variable_name
-#  - variable_name_min_length
-#  - variable_name_max_length
-excluded: # paths to ignore during linting. overridden by `included`.
+# 除外ディレクトリ
+excluded:
   - Carthage
   - Pods
   - fastlane
   - XLProjectName/Helpers/R-Swift/R.generated.swift
-opt_in_rules:
-  - force_unwrapping
+
+# 無効にするルール
+disabled_rules:
+  - line_length            # 1 行の長さ
+  - trailing_whitespace    # 行末に余計なスペース
+  - force_try              # try!
 
 # error 扱いにするルール
-force_cast: error          # [NG] as!
-force_unwrapping: error    # [NG] value!
-opening_brace: error       # [NG] if x == 0{ / [OK] if x == 0 {
-statement_position: error  # [NG] if x == 0 \n { / [OK] if x == 0 {
+force_cast: error              # [NG] as!
+force_unwrapping: error        # [NG] value!
+opening_brace: error           # [NG] if x == 0{ / [OK] if x == 0 {
+statement_position: error      # [NG] if x == 0 \n { / [OK] if x == 0 {
 return_arrow_whitespace: error # [NG] func foo()->Int / [OK] func foo() -> Int
-colon: error               # [NG] let x:Int = 0 / [OK] let x: Int = 0
-comma: error               # [NG] foo(x,y , z) / [OK] foo(x, y, z)
+colon:                         # [NG] let x:Int = 0 / [OK] let x: Int = 0
+  severity: error
+comma:                         # [NG] foo(x,y , z) / [OK] foo(x, y, z)
+  severity: error
+cyclomatic_complexity:         # [NG] 関数内の複雑性(ネストの深いifやifの連続)は程々にしましょう
+  severity: error
+control_statement:             # [NG] if (x == 0) / [OK] if x == 0
+  severity: error 
 
-# warning 扱いにするルール
-control_statement: warning # [NG] if (x == 0) / [OK] if x == 0
-force_try: warning         # [NG] try! throwableFunc()
-
+# 変数名命名規則(id,x,y,z 以外に適用)
 variable_name:
   max_length:
     warning: 30
@@ -57,3 +39,26 @@ variable_name:
     - x
     - y
     - z
+
+# 1行あたりの文字数制限を300に変更
+# プロジェクト作成時にデフォルトで追加されるコメントをひっかけないため
+line_length: 300
+
+# デフォルト無効のルールで有効にするもの
+opt_in_rules:
+- attributes
+- closure_end_indentation
+- closure_spacing
+- empty_count
+- explicit_init
+- explicit_type_interface        # クラス変数とかインスタンス変数とかには"型"を記述した方がいい
+- fatal_error_message            # fatalErrorを使う場合はメッセージを記述した方がいい
+#- implicitly_unwrapped_optional # 暗黙的なUnwrapはやめた方がいい
+- object_literal
+- operator_usage_whitespace
+- overridden_super_call
+#- private_outlet　　　　　　　　　# IBOutletはprivateにしたほうが良い
+- prohibited_super_call
+- redundant_nil_coalescing
+#- sorted_imports                # import部分はソートされているべき
+- switch_case_on_newline

--- a/Project-iOS/XLProjectName/Podfile.lock
+++ b/Project-iOS/XLProjectName/Podfile.lock
@@ -1,0 +1,86 @@
+PODS:
+  - Alamofire (4.4.0)
+  - AlamofireImage (3.2.0):
+    - Alamofire (~> 4.1)
+  - AsyncKit (2.0.1)
+  - Crashlytics (3.9.3):
+    - Fabric (~> 1.7.2)
+  - Decodable (0.6.0)
+  - Device (2.1.0)
+  - Fabric (1.7.2)
+  - KeychainAccess (3.1.0)
+  - Nimble (7.0.3)
+  - NVActivityIndicatorView (3.7.0):
+    - NVActivityIndicatorView/Presenter (= 3.7.0)
+  - NVActivityIndicatorView/Presenter (3.7.0)
+  - OperaSwift (2.0.0):
+    - Alamofire (~> 4.4.0)
+    - RxCocoa (~> 3.4.0)
+    - RxSwift (~> 3.4.0)
+  - Quick (1.2.0)
+  - R.swift (3.3.0):
+    - R.swift.Library (~> 3.0.2)
+  - R.swift.Library (3.0.2)
+  - Realm (2.10.2):
+    - Realm/Headers (= 2.10.2)
+  - Realm/Headers (2.10.2)
+  - RealmSwift (2.10.2):
+    - Realm (= 2.10.2)
+  - RxAlamofire (3.0.3):
+    - RxAlamofire/Core (= 3.0.3)
+  - RxAlamofire/Core (3.0.3):
+    - Alamofire (~> 4.0)
+    - RxSwift (~> 3.0)
+  - RxCocoa (3.4.1):
+    - RxSwift (~> 3.4)
+  - RxSwift (3.4.1)
+  - SwiftLint (0.24.2)
+  - Unbox (2.5.0)
+
+DEPENDENCIES:
+  - Alamofire (~> 4.0)
+  - AlamofireImage (~> 3.0)
+  - AsyncKit (~> 2.0.1)
+  - Crashlytics
+  - Decodable (~> 0.5)
+  - Device (~> 2.0)
+  - Fabric (~> 1.6)
+  - KeychainAccess (~> 3.0)
+  - Nimble (~> 7.0.3)
+  - NVActivityIndicatorView (~> 3.0)
+  - OperaSwift (~> 2.0)
+  - Quick (~> 1.2.0)
+  - R.swift (~> 3.0)
+  - RealmSwift (~> 2.0)
+  - RxAlamofire (~> 3.0)
+  - RxCocoa (~> 3.0)
+  - RxSwift (~> 3.0)
+  - SwiftLint (~> 0.24.2)
+  - Unbox (~> 2.5.0)
+
+SPEC CHECKSUMS:
+  Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
+  AlamofireImage: 157ed682cc81d3b9db4fb90c1f12180ac552d93b
+  AsyncKit: 3817ed496961ea2595d80fe2ff8939398e72f82e
+  Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
+  Decodable: f0b95fa2fcf8633dd097aa8f7f09838ab3524f5d
+  Device: b6f1eac43c482e9b4be50e7606253f2a27449685
+  Fabric: 9cd6a848efcf1b8b07497e0b6a2e7d336353ba15
+  KeychainAccess: 94c5540b32eabf7bc32bfb976a268e8ea05fd6da
+  Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
+  NVActivityIndicatorView: d3738df7e2e476aca0ba6bf32a8c9fbcfc33d64b
+  OperaSwift: c545476deab7a43dab1ca6a273bdb6f79382688f
+  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
+  R.swift: bde9704d50ff36820f49e266bc88ef545e1e9b36
+  R.swift.Library: fbdec16c9802ad104fc1ba53415dc190e6ec5c73
+  Realm: 0ef72b837fb67e9f4b098bac771ddd72c7fdbb69
+  RealmSwift: 07a9ae0505091eda6b2ee7c190c3786d6e90a7b0
+  RxAlamofire: 5eb39188c4917ad98127c0ecb4878a61b7517003
+  RxCocoa: a8a5f1d061d0043e28f56976829f31ce63e8eb09
+  RxSwift: 656f8fbeca5bc372121a72d9ebdd3cd3bc0ffade
+  SwiftLint: 2aa21b96c8d13396a051bc1cb659d2ce1e0075b0
+  Unbox: 30e437e6151a6de16139375fd4e8dd9a664cfbf7
+
+PODFILE CHECKSUM: 166a3a3e38804368b881d0cff2746a4ebee7a71e
+
+COCOAPODS: 1.2.1

--- a/Project-iOS/XLProjectName/XLProjectName/AppDelegate+PushNotification.swift
+++ b/Project-iOS/XLProjectName/XLProjectName/AppDelegate+PushNotification.swift
@@ -28,6 +28,6 @@ extension AppDelegate {
 //        }
     }
     
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
     }
 }

--- a/Project-iOS/XLProjectName/XLProjectName/Helpers/Extensions/NSPredicateExtension.swift
+++ b/Project-iOS/XLProjectName/XLProjectName/Helpers/Extensions/NSPredicateExtension.swift
@@ -108,9 +108,9 @@ extension NSPredicate {
         case .and:
             return NSCompoundPredicate(andPredicateWithSubpredicates: p)
         case .or:
-            return NSCompoundPredicate(orPredicateWithSubpredicates:  p)
+            return NSCompoundPredicate(orPredicateWithSubpredicates: p)
         case .not:
-            return NSCompoundPredicate(notPredicateWithSubpredicate:  self.compound(predicates: p))
+            return NSCompoundPredicate(notPredicateWithSubpredicate: self.compound(predicates: p))
         }
     }
     


### PR DESCRIPTION
resolve #41 

@ist-ikeno 

swiftLint.ymlの記述を最新版に更新しました。
(さすがにテストコードは無いですが)

大きな変更としては新しく  `cyclomatic_complexity` をエラー扱いにしているくらいでしょうか。
(※関数内でネスト深くなったりするなど複雑な処理になってきたらエラー出す)

確認して問題なければマージお願い致します